### PR TITLE
Add github actions workflow for linting and testing the package

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,25 @@
+name: Python package
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.6
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+    - name: Install Tox and any other packages
+      run: |
+        python -m pip install --upgrade pip
+        pip install tox
+    - name: Run Tox
+      run: tox


### PR DESCRIPTION
# Description
This change adds an actions workflow that runs pylint, flake8, black, mypy, and pytest against the package on master branch PR's and pushes.

## Screenshots
![Screen Shot 2020-06-22 at 4 38 30 PM](https://user-images.githubusercontent.com/1132046/85345251-e94e1200-b4a6-11ea-926e-0887184e70f8.png)