### PR TITLE
Strip '\x00' character

### DIFF
--- a/src/license_text_normalizer/main.py
+++ b/src/license_text_normalizer/main.py
@@ -32,7 +32,7 @@ DEFAULT_BULLET_DELIMITERS: List[str] = ["*", "-"]
 
 DEFAULT_TRAILING_DELIMITERS: List[str] = ["*/", "*;", "*"]
 
-DEFAULT_WORDS_TO_STRIP: List[str] = ["\0", "echo", "dnl", "<BR>"]
+DEFAULT_WORDS_TO_STRIP: List[str] = ["\0", "echo", "dnl", "<BR>", "\\x00"]
 
 
 def normalize_license_text(

--- a/tests/fixtures.csv
+++ b/tests/fixtures.csv
@@ -493,3 +493,6 @@ INITIALIZATION AND SEQUENCING REQUIREMENTS
 Copyright (c) 1995-2009 Qualcomm Technologies Incorporated.
 All Rights Reserved.
 Qualcomm Confidential and Proprietary"
+"Questionable extension field!\x00RFC 5639 curve over a 160 bit prime
+field\x00RFC 5639 curve over a 192 bit prime field","Questionable extension field!RFC 5639 curve over a 160 bit prime
+fieldRFC 5639 curve over a 192 bit prime field"

--- a/tests/test_license_text_normalizer.py
+++ b/tests/test_license_text_normalizer.py
@@ -23,7 +23,7 @@ def _load_fixtures(pathname):
 
 
 def test_validate_fixtures_files(fixtures):
-    assert len(fixtures) == 31
+    assert len(fixtures) == 32
 
 
 def test_normalize_license_text(fixtures):


### PR DESCRIPTION
Signed-off-by: Reema Parakh <quic_rparakh@quicinc.com>

# Description

This PR strips the "\x00" character if present anywhere in a provided license text string.

## Steps to Test or Reproduce

Input
`
This is a \x00sample text with \x00char to strip.
`

Output:
`
This is a sample text with char to strip.
`
